### PR TITLE
fixes new user sign-up flow, which wasn't setting a default role value

### DIFF
--- a/src/db/users.js
+++ b/src/db/users.js
@@ -39,6 +39,7 @@ module.exports = function(sequelize, db) {
     },
     role: {
       allowNull: false,
+      defaultValue: 0,
       type: db.INTEGER
     }
   };


### PR DESCRIPTION
I was receiving this error:
```
SequelizeValidationError: notNull Violation: role cannot be null
```
because the sign-up api route doesn't set a value for the role yet is required by the DB model