### PR TITLE
Make environment vars CANON_CONST_* available as globals

### DIFF
--- a/webpack/webpack.config.dev-client.js
+++ b/webpack/webpack.config.dev-client.js
@@ -88,6 +88,12 @@ module.exports = {
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
-    new webpack.DefinePlugin({__DEV__: true, __SERVER__: false, __LOGREDUX__: yn(process.env.CANON_LOGREDUX || true)})
+    new webpack.DefinePlugin({__DEV__: true, __SERVER__: false, __LOGREDUX__: yn(process.env.CANON_LOGREDUX || true)}),
+    new webpack.DefinePlugin(Object.keys(process.env)
+                             .filter(e => e.startsWith('CANON_CONST_'))
+                             .reduce((d, k) => {
+                               d[`__${k.replace('CANON_CONST_', '')}__`] = process.env[k];
+                               return d;
+                             }, {}))
   ]
 };

--- a/webpack/webpack.config.dev-server.js
+++ b/webpack/webpack.config.dev-server.js
@@ -66,6 +66,12 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({__DEV__: true, __SERVER__: true}),
+    new webpack.DefinePlugin(Object.keys(process.env)
+                             .filter(e => e.startsWith('CANON_CONST_'))
+                             .reduce((d, k) => {
+                               d[`__${k.replace('CANON_CONST_', '')}__`] = process.env[k];
+                               return d;
+                             }, {})),
     new webpack.IgnorePlugin(/vertx/)
   ]
 };

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -120,6 +120,12 @@ module.exports = [
       }),
       new webpack.optimize.UglifyJsPlugin({compressor: {warnings: false}, mangle: {keep_fnames: true}}),
       new webpack.DefinePlugin({__DEV__: false, __SERVER__: true}),
+      new webpack.DefinePlugin(Object.keys(process.env)
+                               .filter(e => e.startsWith('CANON_CONST_'))
+                               .reduce((d, k) => {
+                                 d[`__${k.replace('CANON_CONST_', '')}__`] = process.env[k];
+                                 return d;
+                               }, {})),
       new webpack.IgnorePlugin(/vertx/),
       new InlineEnviromentVariablesPlugin({NODE_ENV: "production"})
     ]


### PR DESCRIPTION
Hey @davelandry,

Here's a first try at implementing what you suggested in #40.

Our (datachile) use case is creating a separate virtualhost for hosting static assets. That hostname would be defined as the envvar `CANON_CONST_ASSETS_HOSTS` .