### PR TITLE
Fixes #66 — Resources need to be loaded at init() time.

### DIFF
--- a/src/client.jsx
+++ b/src/client.jsx
@@ -31,10 +31,11 @@ const {CANON_LOGLOCALE, NODE_ENV} = window.__INITIAL_STATE__.env;
 // do rewrite this monstrosity. I hate JS anyway.
 const res = {};
 res[locale] = {};
-res[locale][window.__APP_NAME__] = {
-  ...defaultTranslations,
-  ...resources
-};
+res[locale][window.__APP_NAME__] = resources;
+
+res['canon'] = {};
+res['canon'][window.__APP_NAME__] = defaultTranslations;
+
 
 i18n
   .init({

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -26,6 +26,16 @@ import Canon from "./Canon";
 const {locale, resources} = window.__INITIAL_STATE__.i18n;
 const {CANON_LOGLOCALE, NODE_ENV} = window.__INITIAL_STATE__.env;
 
+
+// XXX If there's a better way to build an object with variable keys, please
+// do rewrite this monstrosity. I hate JS anyway.
+const res = {};
+res[locale] = {};
+res[locale][window.__APP_NAME__] = {
+  ...defaultTranslations,
+  ...resources
+};
+
 i18n
   .init({
     fallbackLng: "canon",
@@ -38,11 +48,10 @@ i18n
     },
     react: {
       wait: true
-    }
+    },
+    resources: res
   });
 
-i18n.addResourceBundle("canon", window.__APP_NAME__, defaultTranslations, true, true);
-i18n.addResourceBundle(locale, window.__APP_NAME__, resources, true, true);
 
 function scrollToHash(hash) {
   const elem = hash && hash.indexOf("#") === 0 ? document.getElementById(hash.slice(1)) : false;


### PR DESCRIPTION
I'm 98.74% sure that this fixes the checksum mismatch issue. Works with canon app, also with Datachile (`npm link`ed canon into datachile)

I'd appreciate a review, test, merge and release.

Thanks.
  