### PR TITLE
Reusable component for social login button

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -3,13 +3,7 @@ import {connect} from "react-redux";
 import {login, resetPassword} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
-
-import facebookIcon from "../images/facebook-logo.svg";
-import twitterIcon from "../images/twitter-logo.svg";
-import instagramIcon from "../images/instagram-logo.svg";
-import googleIcon from "../images/google-logo.svg";
-import githubIcon from "../images/github-logo.svg";
-import linkedinIcon from "../images/linkedin-logo.svg";
+import {SocialButtons} from "src/components/SocialButtons";
 
 import {
   RESET_SEND_FAILURE,
@@ -97,16 +91,7 @@ class Login extends Component {
           </div>
           <button className="pt-button pt-fill" type="submit" tabIndex="5">{ t("Login.Login") }</button>
         </form>
-        { social.length
-          ? <div id="socials">
-            { social.includes("facebook") ? <a href="/auth/facebook" className="pt-button facebook"><img className="icon" src={facebookIcon} /><span>{ t("Login.Facebook") }</span></a> : null }
-            { social.includes("github") ? <a href="/auth/github" className="pt-button github"><img className="icon" src={githubIcon} /><span>{ t("Login.Github") }</span></a> : null }
-            { social.includes("google") ? <a href="/auth/google" className="pt-button google"><img className="icon" src={googleIcon} /><span>{ t("Login.Google") }</span></a> : null }
-            { social.includes("twitter") ? <a href="/auth/twitter" className="pt-button twitter"><img className="icon" src={twitterIcon} /><span>{ t("Login.Twitter") }</span></a> : null }
-            { social.includes("instagram") ? <a href="/auth/instagram" className="pt-button instagram"><img className="icon" src={instagramIcon} /><span>{ t("Login.Instagram") }</span></a> : null }
-            { social.includes("linkedin") ? <a href="/auth/linkedin" className="pt-button linkedin"><img className="icon" src={linkedinIcon} /><span>{ t("Login.LinkedIn") }</span></a> : null }
-          </div>
-          : null }
+        <SocialButtons social={social} />
       </div>
     );
 

--- a/src/components/SignUp.jsx
+++ b/src/components/SignUp.jsx
@@ -3,10 +3,8 @@ import {connect} from "react-redux";
 import {signup} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
+import {SocialButtons} from "src/components/SocialButtons";
 
-import facebookIcon from "../images/facebook-logo.svg";
-import twitterIcon from "../images/twitter-logo.svg";
-import instagramIcon from "../images/instagram-logo.svg";
 import {SIGNUP_EXISTS} from "../consts";
 
 import "./Forms.css";
@@ -111,13 +109,7 @@ class SignUp extends Component {
             : null }
           <button type="submit" className="pt-button pt-fill" tabIndex="5">{ t("SignUp.Sign Up") }</button>
         </form>
-        { social.length
-          ? <div id="socials">
-            { social.includes("facebook") ? <a href="/auth/facebook" className="pt-button facebook"><img className="icon" src={facebookIcon} /><span>{ t("SignUp.Facebook") }</span></a> : null }
-            { social.includes("twitter") ? <a href="/auth/twitter" className="pt-button twitter"><img className="icon" src={twitterIcon} /><span>{ t("SignUp.Twitter") }</span></a> : null }
-            { social.includes("instagram") ? <a href="/auth/instagram" className="pt-button instagram"><img className="icon" src={instagramIcon} /><span>{ t("SignUp.Instagram") }</span></a> : null }
-          </div>
-          : null }
+        <SocialButtons social={social} />
       </div>
     );
 

--- a/src/components/SocialButtons.jsx
+++ b/src/components/SocialButtons.jsx
@@ -1,0 +1,34 @@
+import React, {Component} from "react";
+import facebookIcon from "../images/facebook-logo.svg";
+import twitterIcon from "../images/twitter-logo.svg";
+import instagramIcon from "../images/instagram-logo.svg";
+import googleIcon from "../images/google-logo.svg";
+import githubIcon from "../images/github-logo.svg";
+import linkedinIcon from "../images/linkedin-logo.svg";
+import {translate} from "react-i18next";
+
+class SocialButtons extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const {social, t} = this.props;
+
+    if (!social || !social.length) {
+      return null;
+    }
+    return <div id="socials">
+      { social.includes("facebook") ? <a href="/auth/facebook" className="pt-button facebook"><img className="icon" src={facebookIcon} /><span>{ t("Login.Facebook") }</span></a> : null }
+      { social.includes("github") ? <a href="/auth/github" className="pt-button github"><img className="icon" src={githubIcon} /><span>{ t("Login.Github") }</span></a> : null }
+      { social.includes("google") ? <a href="/auth/google" className="pt-button google"><img className="icon" src={googleIcon} /><span>{ t("Login.Google") }</span></a> : null }
+      { social.includes("twitter") ? <a href="/auth/twitter" className="pt-button twitter"><img className="icon" src={twitterIcon} /><span>{ t("Login.Twitter") }</span></a> : null }
+      { social.includes("instagram") ? <a href="/auth/instagram" className="pt-button instagram"><img className="icon" src={instagramIcon} /><span>{ t("Login.Instagram") }</span></a> : null }
+      { social.includes("linkedin") ? <a href="/auth/linkedin" className="pt-button linkedin"><img className="icon" src={linkedinIcon} /><span>{ t("Login.LinkedIn") }</span></a> : null }
+    </div>;
+  }
+}
+
+SocialButtons = translate()(SocialButtons);
+export {SocialButtons};


### PR DESCRIPTION
Adds a component (SocialButtons) to unify social sharing buttons for login and signup components so that new services will only need to add the buttons in one place. 

(Currently only Twitter and Facebook are in the signup form as I hadn't realized they needed to be added to both places, but instead of copying and pasting thought this might be helpful)