### PR TITLE
Hotfixes social buttons import path for external projects

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -3,7 +3,7 @@ import {connect} from "react-redux";
 import {login, resetPassword} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
-import {SocialButtons} from "src/components/SocialButtons";
+import {SocialButtons} from "../components/SocialButtons";
 
 import {
   RESET_SEND_FAILURE,

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -3,7 +3,7 @@ import {connect} from "react-redux";
 import {login, resetPassword} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
-import {SocialButtons} from "../components/SocialButtons";
+import {SocialButtons} from "./SocialButtons";
 
 import {
   RESET_SEND_FAILURE,

--- a/src/components/SignUp.jsx
+++ b/src/components/SignUp.jsx
@@ -3,7 +3,7 @@ import {connect} from "react-redux";
 import {signup} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
-import {SocialButtons} from "../components/SocialButtons";
+import {SocialButtons} from "./SocialButtons";
 
 import {SIGNUP_EXISTS} from "../consts";
 

--- a/src/components/SignUp.jsx
+++ b/src/components/SignUp.jsx
@@ -3,7 +3,7 @@ import {connect} from "react-redux";
 import {signup} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
-import {SocialButtons} from "src/components/SocialButtons";
+import {SocialButtons} from "../components/SocialButtons";
 
 import {SIGNUP_EXISTS} from "../consts";
 


### PR DESCRIPTION
It looks like I caused a bug in the social buttons components due to the module import path. It would work when testing within canon but when trying to use the components outside of canon from another project the import path gave errors. These changes appear to fix that.