### PR TITLE
fix for reset redirect after password change #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ If you would like to change the default path of the reset link, use the followin
 export CANON_RESET_LINK="/my-reset-route"
 ```
 
-The `<Reset />` component relies on detecting a unique token in the URL (which is sent in the e-mail to the user). If you would like to embed the component into an existing page, you must pass the Router location to the component on render:
+The `<Reset />` component relies on detecting a unique token in the URL (which is sent in the e-mail to the user). If you would like to embed the component into an existing page, you must pass the Router object to the component on render:
 
 ```jsx
-<Reset location={ this.props.location } />
+<Reset router={ this.props.router }/>
 ```
 
 When sending e-mails, datahweel-canon will use the "name" field of your **package.json** file as the site name in e-mail correspondence (ex. "Sincerely, the [name] team"). If you'd like to use a more human-readable site name, it can be set with the following environment variable:

--- a/src/components/Reset.jsx
+++ b/src/components/Reset.jsx
@@ -1,6 +1,5 @@
 import React, {Component} from "react";
 import {connect} from "react-redux";
-import {browserHistory} from "react-router";
 import {changePassword, resetPassword, validateReset} from "../actions/auth";
 import {translate} from "react-i18next";
 import {Intent, Toaster} from "@blueprintjs/core";
@@ -30,7 +29,8 @@ class Reset extends Component {
   }
 
   componentDidMount() {
-    const {token} = this.props.location ? this.props.location.query : this.props;
+    const {location} = this.props.router;
+    const {token} = location ? location.query : this.props;
     if (token) {
       this.props.validateReset(token);
       this.setState({submitted: true});
@@ -43,9 +43,9 @@ class Reset extends Component {
 
   changePassword(e) {
     e.preventDefault();
-    const {t} = this.props;
+    const {t, router} = this.props;
     const {password, passwordAgain, toast} = this.state;
-    const {token} = this.props.location.query;
+    const {token} = router.location.query;
     if (password !== passwordAgain) {
       toast.show({iconName: "error", intent: Intent.DANGER, message: t("SignUp.error.PasswordMatch")});
       return;
@@ -61,8 +61,7 @@ class Reset extends Component {
   }
 
   componentDidUpdate() {
-
-    const {auth, t} = this.props;
+    const {auth, t, router} = this.props;
     const {email, submitted, toast, token} = this.state;
 
     if (!token && auth.msg === RESET_TOKEN_SUCCESS) {
@@ -70,7 +69,7 @@ class Reset extends Component {
     }
     else if (submitted && !auth.loading && (auth.msg || auth.error)) {
       if (auth.msg === RESET_PW_SUCCESS) {
-        browserHistory.push("/login");
+        router.push("/login");
       }
       else if (auth.msg === RESET_SEND_SUCCESS) {
         toast.show({iconName: "inbox", intent: Intent.SUCCESS, message: t("Reset.actions.RESET_SEND_SUCCESS", {email})});
@@ -89,7 +88,6 @@ class Reset extends Component {
   }
 
   render() {
-
     const {t} = this.props;
     const {email, password, passwordAgain, token} = this.state;
 


### PR DESCRIPTION
Currently canon tries to use browserHistory to redirect users after a successful password change which unfortunately doesn't work. This is a proposed fix for redirecting users after successful password change (#91).

_NB_: This PR would introduce a _**breaking**_ change for users embedding the `Reset` component, and would require passing a prop for `router` instead of `location` (see updated docs).