### PR TITLE
[core] puts back in preserving CSS variables

### DIFF
--- a/packages/core/webpack/config/postcss.js
+++ b/packages/core/webpack/config/postcss.js
@@ -46,6 +46,7 @@ module.exports = [
     preserve: false
   }),
   require("postcss-css-variables")({
+    preserve: true,
     variables
   }),
   require("postcss-map")({


### PR DESCRIPTION
@jhmullen this was the thing I rolled back in the v0.23 core, but it's what we need for light/dark mode in the OEC. This should just be a quick canon-core hotfix.