### PR TITLE
updates .gitignore to include prod index.js

### DIFF
--- a/packages/create-canon/scaffold/dot_gitignore
+++ b/packages/create-canon/scaffold/dot_gitignore
@@ -7,7 +7,7 @@ node_modules
 # these static files will be generated on build
 **/static/assets
 **/static/reports
-**/*.bundle.js
+/index.js
 
 # environment variable files for autoenv and direnv
 .env


### PR DESCRIPTION
This change adds the `./index.js` file created with `npm run build` to the `.gitignore` file, and removes `**/*.bundle.js` (I'm not sure what that one was referencing?)